### PR TITLE
Rebrand project as osls compose

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-This repository contains the code for OSLS Compose.
+This repository contains the code for osls compose.
 
 Requires Node.js `^20.19.0 || ^22.13.0 || >=24`.
 
@@ -11,6 +11,6 @@ osls-compose --help
 
 Available commands: `osls-compose`, `oslsc`.
 
-Check out the [OSLS Compose documentation](https://github.com/oss-serverless/framework/blob/main/docs/guides/compose.md).
+Check out the [osls compose documentation](https://github.com/oss-serverless/osls/blob/main/docs/guides/compose.md).
 
-<p align="center"><a href="https://github.com/oss-serverless/framework/blob/main/docs/guides/compose.md"><img src="https://assets.website-files.com/6178ec21bdb27bb4cd52c72d/625d76707477fa1efbb3559d_blog%20header.png" width="600px"></a></p>
+<p align="center"><a href="https://github.com/oss-serverless/osls/blob/main/docs/guides/compose.md"><img src="https://assets.website-files.com/6178ec21bdb27bb4cd52c72d/625d76707477fa1efbb3559d_blog%20header.png" width="600px"></a></p>

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-This repository contains the code for Serverless Framework Compose.
+This repository contains the code for OSLS Compose.
 
 Requires Node.js `^20.19.0 || ^22.13.0 || >=24`.
 
@@ -11,6 +11,6 @@ osls-compose --help
 
 Available commands: `osls-compose`, `oslsc`.
 
-Check out the [Serverless Framework Compose documentation](https://github.com/oss-serverless/serverless/blob/main/docs/guides/compose.md).
+Check out the [OSLS Compose documentation](https://github.com/oss-serverless/framework/blob/main/docs/guides/compose.md).
 
-<p align="center"><a href="https://github.com/oss-serverless/serverless/blob/main/docs/guides/compose.md"><img src="https://assets.website-files.com/6178ec21bdb27bb4cd52c72d/625d76707477fa1efbb3559d_blog%20header.png" width="600px"></a></p>
+<p align="center"><a href="https://github.com/oss-serverless/framework/blob/main/docs/guides/compose.md"><img src="https://assets.website-files.com/6178ec21bdb27bb4cd52c72d/625d76707477fa1efbb3559d_blog%20header.png" width="600px"></a></p>

--- a/bin/serverless-compose
+++ b/bin/serverless-compose
@@ -11,7 +11,7 @@ const isSupportedNodeVersion = require('../src/cli/is-supported-node-version');
 if (!isSupportedNodeVersion(process.version)) {
   const composeVersion = require('../package.json').version;
   process.stderr.write(
-    `Error: Serverless Framework Compose v${composeVersion} does not support ` +
+    `Error: OSLS Compose v${composeVersion} does not support ` +
       `Node.js ${process.version}. Please use a supported release. ` +
       `Supported versions: ${isSupportedNodeVersion.supportedRange}.\n`
   );

--- a/bin/serverless-compose
+++ b/bin/serverless-compose
@@ -11,7 +11,7 @@ const isSupportedNodeVersion = require('../src/cli/is-supported-node-version');
 if (!isSupportedNodeVersion(process.version)) {
   const composeVersion = require('../package.json').version;
   process.stderr.write(
-    `Error: OSLS Compose v${composeVersion} does not support ` +
+    `Error: osls compose v${composeVersion} does not support ` +
       `Node.js ${process.version}. Please use a supported release. ` +
       `Supported versions: ${isSupportedNodeVersion.supportedRange}.\n`
   );

--- a/components/framework/index.js
+++ b/components/framework/index.js
@@ -54,7 +54,7 @@ class ServerlessFramework {
 
     if (path.relative(process.cwd(), inputs.path) === '') {
       throw new ServerlessError(
-        `Service "${id}" cannot have a "path" that points to the root directory of the OSLS Compose project`,
+        `Service "${id}" cannot have a "path" that points to the root directory of the osls compose project`,
         'INVALID_PATH_IN_SERVICE_CONFIGURATION'
       );
     }
@@ -72,7 +72,7 @@ class ServerlessFramework {
   //     handler: async () => await this.command(['package']),
   //   },
   // };
-  // For now the workaround is to just pray that the command is correct and rely on validation from OSLS Framework
+  // For now the workaround is to just pray that the command is correct and rely on validation from osls
   async command(command, options) {
     const progressText = COMMAND_PROGRESS_TEXT[command];
     if (progressText) {
@@ -219,7 +219,7 @@ class ServerlessFramework {
         stdoutResult = stdoutBuffer.toString();
       } catch (e) {
         throw new Error(
-          'Could not find the OSLS Framework CLI installation. Ensure OSLS Framework is installed before continuing.\nhttps://github.com/oss-serverless/framework',
+          'Could not find the osls CLI installation. Ensure osls is installed before continuing.\nhttps://github.com/oss-serverless/osls',
           { cause: e }
         );
       }
@@ -230,13 +230,13 @@ class ServerlessFramework {
       }
       if (!matchResult) {
         throw new Error(
-          'Could not verify the OSLS Framework CLI installation. Ensure OSLS Framework is installed before continuing.\nhttps://github.com/oss-serverless/framework'
+          'Could not verify the osls CLI installation. Ensure osls is installed before continuing.\nhttps://github.com/oss-serverless/osls'
         );
       }
       const version = matchResult[1];
       if (!doesSatisfyRequiredFrameworkVersion(version)) {
         throw new Error(
-          `The installed version of OSLS Framework (${version}) is not supported by Compose. Please upgrade OSLS Framework to a version greater or equal to "${MINIMAL_FRAMEWORK_VERSION}"`
+          `The installed version of osls (${version}) is not supported by osls compose. Please upgrade osls to a version greater or equal to "${MINIMAL_FRAMEWORK_VERSION}"`
         );
       }
       // Stored to avoid checking it on each invocation

--- a/components/framework/index.js
+++ b/components/framework/index.js
@@ -236,7 +236,7 @@ class ServerlessFramework {
       const version = matchResult[1];
       if (!doesSatisfyRequiredFrameworkVersion(version)) {
         throw new Error(
-          `The installed version of osls (${version}) is not supported by osls compose. Please upgrade osls to a version greater or equal to "${MINIMAL_FRAMEWORK_VERSION}"`
+          `The installed version of osls (${version}) is not supported by osls compose. Please upgrade osls to a version greater than or equal to "${MINIMAL_FRAMEWORK_VERSION}"`
         );
       }
       // Stored to avoid checking it on each invocation

--- a/components/framework/index.js
+++ b/components/framework/index.js
@@ -54,7 +54,7 @@ class ServerlessFramework {
 
     if (path.relative(process.cwd(), inputs.path) === '') {
       throw new ServerlessError(
-        `Service "${id}" cannot have a "path" that points to the root directory of the Serverless Framework Compose project`,
+        `Service "${id}" cannot have a "path" that points to the root directory of the OSLS Compose project`,
         'INVALID_PATH_IN_SERVICE_CONFIGURATION'
       );
     }
@@ -72,7 +72,7 @@ class ServerlessFramework {
   //     handler: async () => await this.command(['package']),
   //   },
   // };
-  // For now the workaround is to just pray that the command is correct and rely on validation from the Framework
+  // For now the workaround is to just pray that the command is correct and rely on validation from OSLS Framework
   async command(command, options) {
     const progressText = COMMAND_PROGRESS_TEXT[command];
     if (progressText) {
@@ -219,7 +219,7 @@ class ServerlessFramework {
         stdoutResult = stdoutBuffer.toString();
       } catch (e) {
         throw new Error(
-          'Could not find the Serverless Framework CLI installation. Ensure Serverless Framework is installed before continuing.\nhttps://github.com/oss-serverless/serverless',
+          'Could not find the OSLS Framework CLI installation. Ensure OSLS Framework is installed before continuing.\nhttps://github.com/oss-serverless/framework',
           { cause: e }
         );
       }
@@ -230,13 +230,13 @@ class ServerlessFramework {
       }
       if (!matchResult) {
         throw new Error(
-          'Could not verify the Serverless Framework CLI installation. Ensure Serverless Framework is installed before continuing.\nhttps://github.com/oss-serverless/serverless'
+          'Could not verify the OSLS Framework CLI installation. Ensure OSLS Framework is installed before continuing.\nhttps://github.com/oss-serverless/framework'
         );
       }
       const version = matchResult[1];
       if (!doesSatisfyRequiredFrameworkVersion(version)) {
         throw new Error(
-          `The installed version of Serverless Framework (${version}) is not supported by Compose. Please upgrade Serverless Framework to a version greater or equal to "${MINIMAL_FRAMEWORK_VERSION}"`
+          `The installed version of OSLS Framework (${version}) is not supported by Compose. Please upgrade OSLS Framework to a version greater or equal to "${MINIMAL_FRAMEWORK_VERSION}"`
         );
       }
       // Stored to avoid checking it on each invocation

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@osls/compose",
   "version": "1.3.0",
-  "description": "Deploy and orchestrate multiple Serverless Framework services in monorepositories.",
+  "description": "OSLS Compose for deploying and orchestrating multiple services in monorepositories.",
   "main": "src/index.js",
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@osls/compose",
   "version": "1.3.0",
-  "description": "OSLS Compose for deploying and orchestrating multiple services in monorepositories.",
+  "description": "osls compose for deploying and orchestrating multiple services in monorepositories.",
   "main": "src/index.js",
   "repository": {
     "type": "git",

--- a/src/ComponentsService.js
+++ b/src/ComponentsService.js
@@ -360,10 +360,10 @@ class ComponentsService {
       'refresh-outputs',
       'package',
     ];
-    // Specific error messages for popular OSLS Framework commands
+    // Specific error messages for popular osls commands
     if (command === 'invoke') {
       throw new ServerlessError(
-        `"invoke" is not a global command in OSLS Compose.\nAvailable global commands: ${globalCommands.join(
+        `"invoke" is not a global command in osls compose.\nAvailable global commands: ${globalCommands.join(
           ', '
         )}.\nYou can invoke functions by running "serverless <service-name>:invoke --function <function>".`,
         'COMMAND_NOT_FOUND'
@@ -371,7 +371,7 @@ class ComponentsService {
     }
     if (command === 'offline') {
       throw new ServerlessError(
-        `"offline" is not a global command in OSLS Compose.\nAvailable global commands: ${globalCommands.join(
+        `"offline" is not a global command in osls compose.\nAvailable global commands: ${globalCommands.join(
           ', '
         )}.\nYou can run serverless-offline in each service by running "serverless <service-name>:${command}".`,
         'COMMAND_NOT_FOUND'
@@ -434,7 +434,7 @@ class ComponentsService {
         }
         handler = (opts) => component[command](opts);
       } else if (!hasCustomCommand && component instanceof ServerlessFramework) {
-        // Workaround to invoke all custom OSLS Framework commands
+        // Workaround to invoke all custom osls commands
         // TODO: Support options and validation
         handler = (opts) => component.command(command, opts);
       } else {

--- a/src/ComponentsService.js
+++ b/src/ComponentsService.js
@@ -360,10 +360,10 @@ class ComponentsService {
       'refresh-outputs',
       'package',
     ];
-    // Specific error messages for popular Framework commands
+    // Specific error messages for popular OSLS Framework commands
     if (command === 'invoke') {
       throw new ServerlessError(
-        `"invoke" is not a global command in Serverless Framework Compose.\nAvailable global commands: ${globalCommands.join(
+        `"invoke" is not a global command in OSLS Compose.\nAvailable global commands: ${globalCommands.join(
           ', '
         )}.\nYou can invoke functions by running "serverless <service-name>:invoke --function <function>".`,
         'COMMAND_NOT_FOUND'
@@ -371,9 +371,9 @@ class ComponentsService {
     }
     if (command === 'offline') {
       throw new ServerlessError(
-        `"offline" is not a global command in Serverless Framework Compose.\nAvailable global commands: ${globalCommands.join(
+        `"offline" is not a global command in OSLS Compose.\nAvailable global commands: ${globalCommands.join(
           ', '
-        )}.\nYou can run serverless-offline in each Serverless Framework service by running "serverless <service-name>:${command}".`,
+        )}.\nYou can run serverless-offline in each service by running "serverless <service-name>:${command}".`,
         'COMMAND_NOT_FOUND'
       );
     }
@@ -434,7 +434,7 @@ class ComponentsService {
         }
         handler = (opts) => component[command](opts);
       } else if (!hasCustomCommand && component instanceof ServerlessFramework) {
-        // Workaround to invoke all custom Framework commands
+        // Workaround to invoke all custom OSLS Framework commands
         // TODO: Support options and validation
         handler = (opts) => component.command(command, opts);
       } else {

--- a/src/Context.js
+++ b/src/Context.js
@@ -30,7 +30,7 @@ class Context {
       this.progresses.setFooterText(stderrCliColors.gray('Press [?] to enable verbose logs'));
     }
 
-    // Resolved Compose configuration
+    // Resolved osls compose configuration
     this.configuration = config.configuration;
   }
 

--- a/src/configuration/read.js
+++ b/src/configuration/read.js
@@ -8,9 +8,9 @@ const yaml = require('js-yaml');
 const spawn = require('../utils/spawn');
 const ServerlessError = require('../serverless-error');
 
-// Logic for TS resolution is kept as similar as possible to the Serverless Framework codebase
+// Logic for TS resolution is kept as similar as possible to the OSLS Framework codebase
 const resolveTsNode = async (serviceDir) => {
-  // 1. If installed aside of a Framework, use it
+  // 1. If installed alongside OSLS Framework, use it
   try {
     return createRequire(path.resolve(__dirname, 'require-resolver')).resolve('ts-node');
   } catch (slsDepError) {

--- a/src/configuration/read.js
+++ b/src/configuration/read.js
@@ -8,9 +8,9 @@ const yaml = require('js-yaml');
 const spawn = require('../utils/spawn');
 const ServerlessError = require('../serverless-error');
 
-// Logic for TS resolution is kept as similar as possible to the OSLS Framework codebase
+// Logic for TS resolution is kept as similar as possible to the osls codebase
 const resolveTsNode = async (serviceDir) => {
-  // 1. If installed alongside OSLS Framework, use it
+  // 1. If installed alongside osls, use it
   try {
     return createRequire(path.resolve(__dirname, 'require-resolver')).resolve('ts-node');
   } catch (slsDepError) {

--- a/src/configuration/resolve-variables.js
+++ b/src/configuration/resolve-variables.js
@@ -5,7 +5,7 @@ const traverse = require('traverse');
 const ServerlessError = require('../serverless-error');
 
 // For now, only supported variables are `${sls:stage}` and `${env:<key>}`;
-// TODO: After merging into Framework CLI, unify the configuration resolution handling with Framework logic
+// TODO: After merging into OSLS Framework CLI, unify the configuration resolution handling with OSLS Framework logic
 const resolveConfigurationVariables = async (
   configuration,
   configurationPath,
@@ -66,11 +66,11 @@ const resolveConfigurationVariables = async (
     );
     if (usedFrameworkOnlyVariableSources.length) {
       if (usedFrameworkOnlyVariableSources.length === 1) {
-        errorMessage += `\n\nVariable source "${usedFrameworkOnlyVariableSources[0]}" is Serverless Framework-specific source that is not supported in "${configurationFilename}"`;
+        errorMessage += `\n\nVariable source "${usedFrameworkOnlyVariableSources[0]}" is OSLS Framework-specific source that is not supported in "${configurationFilename}"`;
       } else {
         errorMessage += `\n\nVariable sources "${usedFrameworkOnlyVariableSources.join(
           '", "'
-        )}" are Serverless Framework-specific sources that are not supported in "${configurationFilename}"`;
+        )}" are OSLS Framework-specific sources that are not supported in "${configurationFilename}"`;
       }
     }
 

--- a/src/configuration/resolve-variables.js
+++ b/src/configuration/resolve-variables.js
@@ -5,7 +5,7 @@ const traverse = require('traverse');
 const ServerlessError = require('../serverless-error');
 
 // For now, only supported variables are `${sls:stage}` and `${env:<key>}`;
-// TODO: After merging into OSLS Framework CLI, unify the configuration resolution handling with OSLS Framework logic
+// TODO: After merging into osls CLI, unify the configuration resolution handling with osls logic
 const resolveConfigurationVariables = async (
   configuration,
   configurationPath,
@@ -66,11 +66,11 @@ const resolveConfigurationVariables = async (
     );
     if (usedFrameworkOnlyVariableSources.length) {
       if (usedFrameworkOnlyVariableSources.length === 1) {
-        errorMessage += `\n\nVariable source "${usedFrameworkOnlyVariableSources[0]}" is OSLS Framework-specific source that is not supported in "${configurationFilename}"`;
+        errorMessage += `\n\nVariable source "${usedFrameworkOnlyVariableSources[0]}" is osls-specific source that is not supported in "${configurationFilename}"`;
       } else {
         errorMessage += `\n\nVariable sources "${usedFrameworkOnlyVariableSources.join(
           '", "'
-        )}" are OSLS Framework-specific sources that are not supported in "${configurationFilename}"`;
+        )}" are osls-specific sources that are not supported in "${configurationFilename}"`;
       }
     }
 

--- a/src/configuration/resolve-variables.js
+++ b/src/configuration/resolve-variables.js
@@ -5,7 +5,7 @@ const traverse = require('traverse');
 const ServerlessError = require('../serverless-error');
 
 // For now, only supported variables are `${sls:stage}` and `${env:<key>}`;
-// TODO: After merging into osls CLI, unify the configuration resolution handling with osls logic
+// TODO: After merging into the osls CLI, unify the configuration resolution handling with osls logic
 const resolveConfigurationVariables = async (
   configuration,
   configurationPath,
@@ -66,7 +66,7 @@ const resolveConfigurationVariables = async (
     );
     if (usedFrameworkOnlyVariableSources.length) {
       if (usedFrameworkOnlyVariableSources.length === 1) {
-        errorMessage += `\n\nVariable source "${usedFrameworkOnlyVariableSources[0]}" is osls-specific source that is not supported in "${configurationFilename}"`;
+        errorMessage += `\n\nVariable source "${usedFrameworkOnlyVariableSources[0]}" is an osls-specific source that is not supported in "${configurationFilename}"`;
       } else {
         errorMessage += `\n\nVariable sources "${usedFrameworkOnlyVariableSources.join(
           '", "'

--- a/src/configuration/validate.js
+++ b/src/configuration/validate.js
@@ -10,8 +10,8 @@ function validateConfiguration(configuration, configurationPath) {
   const configurationFilename = path.basename(configurationPath);
   if (configuration == null || typeof configuration !== 'object') {
     throw new ServerlessError(
-      `Resolved "${configurationFilename}" does not contain valid Compose configuration.\n` +
-        'Read about OSLS Compose in the documentation: https://github.com/oss-serverless/framework/blob/main/docs/guides/compose.md',
+      `Resolved "${configurationFilename}" does not contain valid osls compose configuration.\n` +
+        'Read about osls compose in the documentation: https://github.com/oss-serverless/osls/blob/main/docs/guides/compose.md',
       'INVALID_NON_OBJECT_CONFIGURATION'
     );
   }
@@ -19,7 +19,7 @@ function validateConfiguration(configuration, configurationPath) {
   if (!hasOwn(configuration, 'services') || !isObject(configuration.services)) {
     throw new ServerlessError(
       `Invalid configuration: "${configurationFilename}" must contain "services" property.\n` +
-        'Read about OSLS Compose configuration in the documentation: https://github.com/oss-serverless/framework/blob/main/docs/guides/compose.md',
+        'Read about osls compose configuration in the documentation: https://github.com/oss-serverless/osls/blob/main/docs/guides/compose.md',
       'INVALID_NON_OBJECT_SERVICES_CONFIGURATION'
     );
   }
@@ -35,13 +35,13 @@ function validateConfiguration(configuration, configurationPath) {
     if (!isObject(value)) {
       throw new ServerlessError(
         `Invalid configuration: definition of "${key}" service must be an object.\n` +
-          'Read about OSLS Compose configuration in the documentation: https://github.com/oss-serverless/framework/blob/main/docs/guides/compose.md',
+          'Read about osls compose configuration in the documentation: https://github.com/oss-serverless/osls/blob/main/docs/guides/compose.md',
         'INVALID_NON_OBJECT_SERVICE_CONFIGURATION'
       );
     }
   });
 
-  // Provide a targeted error message if users use OSLS Framework options
+  // Provide a targeted error message if users use osls options
   const frameworkConfigKeys = [
     'service',
     'provider',
@@ -58,7 +58,7 @@ function validateConfiguration(configuration, configurationPath) {
     if (hasOwn(configuration, key)) {
       throw new ServerlessError(
         `Invalid property "${key}" in "${configurationFilename}".\n` +
-          'This is an OSLS Framework option (serverless.yml) that is not supported in serverless-compose.yml.\n' +
+          'This is an osls option (serverless.yml) that is not supported in serverless-compose.yml.\n' +
           'You can search and/or open feature requests here: https://github.com/oss-serverless/compose/issues',
         'INVALID_CONFIGURATION'
       );
@@ -73,7 +73,7 @@ function validateConfiguration(configuration, configurationPath) {
   if (extraProperties.length > 0) {
     throw new ServerlessError(
       `Unrecognized property ${extraProperties.join(', ')} in "${configurationFilename}".\n` +
-        'Read about OSLS Compose configuration in the documentation: https://github.com/oss-serverless/framework/blob/main/docs/guides/compose.md',
+        'Read about osls compose configuration in the documentation: https://github.com/oss-serverless/osls/blob/main/docs/guides/compose.md',
       'INVALID_CONFIGURATION'
     );
   }

--- a/src/configuration/validate.js
+++ b/src/configuration/validate.js
@@ -11,7 +11,7 @@ function validateConfiguration(configuration, configurationPath) {
   if (configuration == null || typeof configuration !== 'object') {
     throw new ServerlessError(
       `Resolved "${configurationFilename}" does not contain valid Compose configuration.\n` +
-        'Read about Serverless Framework Compose in the documentation: https://slss.io/docs-compose',
+        'Read about OSLS Compose in the documentation: https://github.com/oss-serverless/framework/blob/main/docs/guides/compose.md',
       'INVALID_NON_OBJECT_CONFIGURATION'
     );
   }
@@ -19,7 +19,7 @@ function validateConfiguration(configuration, configurationPath) {
   if (!hasOwn(configuration, 'services') || !isObject(configuration.services)) {
     throw new ServerlessError(
       `Invalid configuration: "${configurationFilename}" must contain "services" property.\n` +
-        'Read about Serverless Framework Compose configuration in the documentation: https://slss.io/docs-compose',
+        'Read about OSLS Compose configuration in the documentation: https://github.com/oss-serverless/framework/blob/main/docs/guides/compose.md',
       'INVALID_NON_OBJECT_SERVICES_CONFIGURATION'
     );
   }
@@ -35,13 +35,13 @@ function validateConfiguration(configuration, configurationPath) {
     if (!isObject(value)) {
       throw new ServerlessError(
         `Invalid configuration: definition of "${key}" service must be an object.\n` +
-          'Read about Serverless Framework Compose configuration in the documentation: https://slss.io/docs-compose',
+          'Read about OSLS Compose configuration in the documentation: https://github.com/oss-serverless/framework/blob/main/docs/guides/compose.md',
         'INVALID_NON_OBJECT_SERVICE_CONFIGURATION'
       );
     }
   });
 
-  // Provide a targeted error message if users use Framework options
+  // Provide a targeted error message if users use OSLS Framework options
   const frameworkConfigKeys = [
     'service',
     'provider',
@@ -58,8 +58,8 @@ function validateConfiguration(configuration, configurationPath) {
     if (hasOwn(configuration, key)) {
       throw new ServerlessError(
         `Invalid property "${key}" in "${configurationFilename}".\n` +
-          'This is a Serverless Framework option (serverless.yml) that is not supported in serverless-compose.yml.\n' +
-          'You can search and/or open feature requests here: https://slss.io/docs-compose',
+          'This is an OSLS Framework option (serverless.yml) that is not supported in serverless-compose.yml.\n' +
+          'You can search and/or open feature requests here: https://github.com/oss-serverless/compose/issues',
         'INVALID_CONFIGURATION'
       );
     }
@@ -73,7 +73,7 @@ function validateConfiguration(configuration, configurationPath) {
   if (extraProperties.length > 0) {
     throw new ServerlessError(
       `Unrecognized property ${extraProperties.join(', ')} in "${configurationFilename}".\n` +
-        'Read about Serverless Framework Compose configuration in the documentation: https://slss.io/docs-compose',
+        'Read about OSLS Compose configuration in the documentation: https://github.com/oss-serverless/framework/blob/main/docs/guides/compose.md',
       'INVALID_CONFIGURATION'
     );
   }

--- a/src/render-help.js
+++ b/src/render-help.js
@@ -42,7 +42,7 @@ function formatLine(commandOrOption, description) {
 
 module.exports = async () => {
   const output = new Output(false);
-  output.writeText(`OSLS Compose v${version}`);
+  output.writeText(`osls compose v${version}`);
   output.writeText();
   output.writeText(colors.gray('Usage'));
   output.writeText('serverless <command> <options>');

--- a/src/render-help.js
+++ b/src/render-help.js
@@ -42,7 +42,7 @@ function formatLine(commandOrOption, description) {
 
 module.exports = async () => {
   const output = new Output(false);
-  output.writeText(`Serverless Framework Compose v${version}`);
+  output.writeText(`OSLS Compose v${version}`);
   output.writeText();
   output.writeText(colors.gray('Usage'));
   output.writeText('serverless <command> <options>');

--- a/src/state/utils/remote-state-cloudformation-template.json
+++ b/src/state/utils/remote-state-cloudformation-template.json
@@ -1,6 +1,6 @@
 {
   "AWSTemplateFormatVersion": "2010-09-09",
-  "Description": "The AWS CloudFormation template for osls compose Remote State S3 Bucket",
+  "Description": "The AWS CloudFormation template for osls compose remote state S3 bucket",
   "Parameters": {
     "BucketName": {
       "Description": "Name of the created state bucket",

--- a/src/state/utils/remote-state-cloudformation-template.json
+++ b/src/state/utils/remote-state-cloudformation-template.json
@@ -1,6 +1,6 @@
 {
   "AWSTemplateFormatVersion": "2010-09-09",
-  "Description": "The AWS CloudFormation template for Serverless Compose Remote State S3 Bucket",
+  "Description": "The AWS CloudFormation template for OSLS Compose Remote State S3 Bucket",
   "Parameters": {
     "BucketName": {
       "Description": "Name of the created state bucket",

--- a/src/state/utils/remote-state-cloudformation-template.json
+++ b/src/state/utils/remote-state-cloudformation-template.json
@@ -1,6 +1,6 @@
 {
   "AWSTemplateFormatVersion": "2010-09-09",
-  "Description": "The AWS CloudFormation template for OSLS Compose Remote State S3 Bucket",
+  "Description": "The AWS CloudFormation template for osls compose Remote State S3 Bucket",
   "Parameters": {
     "BucketName": {
       "Description": "Name of the created state bucket",

--- a/src/utils/serverless-utils/README.md
+++ b/src/utils/serverless-utils/README.md
@@ -1,13 +1,13 @@
-Curated `@serverless/utils` vendor for compose
+Curated `@serverless/utils` vendor for osls compose
 
 This subtree contains the small logging/reporting slice of `@serverless/utils`
-that compose still needs at process startup.
+that osls compose still needs at process startup.
 
 It is internal only.
-Compose does not alias any `@serverless/utils/*` import paths to this
+osls compose does not alias any `@serverless/utils/*` import paths to this
 directory.
 
-Loaded components should use the compose `ComponentContext` API for logging and
+Loaded components should use the osls compose `ComponentContext` API for logging and
 progress. If a component wants to use `@serverless/utils/*`, it must declare
 that dependency itself.
 

--- a/src/validate-options.js
+++ b/src/validate-options.js
@@ -3,22 +3,22 @@
 const ServerlessError = require('./serverless-error');
 
 function validateCliOptions(options, method) {
-  // Catch early OSLS Framework CLI-wide options that aren't supported here
+  // Catch early osls CLI-wide options that aren't supported here
   // Since these are reserved options, we don't even want component-specific commands to support them
   // so we detect these early for _all_ commands.
   const unsupportedGlobalCliOptions = ['debug', 'config', 'param'];
   unsupportedGlobalCliOptions.forEach((option) => {
     if (options[option]) {
       throw new ServerlessError(
-        `The "--${option}" option is not supported (yet) in OSLS Compose\nYou can search and/or open feature requests here: https://github.com/oss-serverless/compose/issues`,
+        `The "--${option}" option is not supported (yet) in osls compose\nYou can search and/or open feature requests here: https://github.com/oss-serverless/compose/issues`,
         'INVALID_GLOBAL_CLI_OPTION'
       );
     }
   });
 
-  // Globally recognized options for global Compose methods
+  // Globally recognized options for global osls compose methods
   const supportedOptions = new Set(['verbose', 'stage', 'max-concurrency']);
-  // We only validate methods that are explicitly recognized by Compose (excluding pass-through methods for OSLS Framework)
+  // We only validate methods that are explicitly recognized by osls compose (excluding pass-through methods for osls)
 
   const recognizedMethods = new Set([
     'deploy',
@@ -58,11 +58,11 @@ function validateCliOptions(options, method) {
 
   if (usedFrameworkSpecificCliOptions.length) {
     if (usedFrameworkSpecificCliOptions.length === 1) {
-      errorMessage += `\n\nCLI option "--${usedFrameworkSpecificCliOptions[0]}" is OSLS Framework-specific option that is not supported in Compose`;
+      errorMessage += `\n\nCLI option "--${usedFrameworkSpecificCliOptions[0]}" is osls-specific option that is not supported in osls compose`;
     } else {
       errorMessage += `\n\nCLI options "--${usedFrameworkSpecificCliOptions.join(
         '", "--'
-      )}" are OSLS Framework-specific options that are not supported in Compose`;
+      )}" are osls-specific options that are not supported in osls compose`;
     }
   }
   throw new ServerlessError(errorMessage, 'UNRECOGNIZED_CLI_OPTIONS');

--- a/src/validate-options.js
+++ b/src/validate-options.js
@@ -3,14 +3,14 @@
 const ServerlessError = require('./serverless-error');
 
 function validateCliOptions(options, method) {
-  // Catch early Framework CLI-wide options that aren't supported here
+  // Catch early OSLS Framework CLI-wide options that aren't supported here
   // Since these are reserved options, we don't even want component-specific commands to support them
   // so we detect these early for _all_ commands.
   const unsupportedGlobalCliOptions = ['debug', 'config', 'param'];
   unsupportedGlobalCliOptions.forEach((option) => {
     if (options[option]) {
       throw new ServerlessError(
-        `The "--${option}" option is not supported (yet) in Serverless Framework Compose\nYou can search and/or open feature requests here: https://github.com/oss-serverless/compose'`,
+        `The "--${option}" option is not supported (yet) in OSLS Compose\nYou can search and/or open feature requests here: https://github.com/oss-serverless/compose/issues`,
         'INVALID_GLOBAL_CLI_OPTION'
       );
     }
@@ -18,7 +18,7 @@ function validateCliOptions(options, method) {
 
   // Globally recognized options for global Compose methods
   const supportedOptions = new Set(['verbose', 'stage', 'max-concurrency']);
-  // We only validate methods that are explicitly recognized by Compose (excluding pass-through methods for Framework)
+  // We only validate methods that are explicitly recognized by Compose (excluding pass-through methods for OSLS Framework)
 
   const recognizedMethods = new Set([
     'deploy',
@@ -58,11 +58,11 @@ function validateCliOptions(options, method) {
 
   if (usedFrameworkSpecificCliOptions.length) {
     if (usedFrameworkSpecificCliOptions.length === 1) {
-      errorMessage += `\n\nCLI option "--${usedFrameworkSpecificCliOptions[0]}" is Serverless Framework-specific option that is not supported in Compose`;
+      errorMessage += `\n\nCLI option "--${usedFrameworkSpecificCliOptions[0]}" is OSLS Framework-specific option that is not supported in Compose`;
     } else {
       errorMessage += `\n\nCLI options "--${usedFrameworkSpecificCliOptions.join(
         '", "--'
-      )}" are Serverless Framework-specific options that are not supported in Compose`;
+      )}" are OSLS Framework-specific options that are not supported in Compose`;
     }
   }
   throw new ServerlessError(errorMessage, 'UNRECOGNIZED_CLI_OPTIONS');

--- a/src/validate-options.js
+++ b/src/validate-options.js
@@ -58,7 +58,7 @@ function validateCliOptions(options, method) {
 
   if (usedFrameworkSpecificCliOptions.length) {
     if (usedFrameworkSpecificCliOptions.length === 1) {
-      errorMessage += `\n\nCLI option "--${usedFrameworkSpecificCliOptions[0]}" is osls-specific option that is not supported in osls compose`;
+      errorMessage += `\n\nCLI option "--${usedFrameworkSpecificCliOptions[0]}" is an osls-specific option that is not supported in osls compose`;
     } else {
       errorMessage += `\n\nCLI options "--${usedFrameworkSpecificCliOptions.join(
         '", "--'

--- a/test/unit/bin/serverless-compose.test.js
+++ b/test/unit/bin/serverless-compose.test.js
@@ -37,7 +37,7 @@ describe('test/unit/bin/serverless-compose.test.js', () => {
 
     expect(isSupportedNodeVersion).to.have.been.calledOnceWithExactly(process.version);
     expect(stderrWrite).to.have.been.calledOnceWithExactly(
-      'Error: OSLS Compose v1.3.0 does not support ' +
+      'Error: osls compose v1.3.0 does not support ' +
         `Node.js ${process.version}. Please use a supported release. ` +
         'Supported versions: ^20.19.0 || ^22.13.0 || >=24.\n'
     );

--- a/test/unit/bin/serverless-compose.test.js
+++ b/test/unit/bin/serverless-compose.test.js
@@ -37,7 +37,7 @@ describe('test/unit/bin/serverless-compose.test.js', () => {
 
     expect(isSupportedNodeVersion).to.have.been.calledOnceWithExactly(process.version);
     expect(stderrWrite).to.have.been.calledOnceWithExactly(
-      'Error: Serverless Framework Compose v1.3.0 does not support ' +
+      'Error: OSLS Compose v1.3.0 does not support ' +
         `Node.js ${process.version}. Please use a supported release. ` +
         'Supported versions: ^20.19.0 || ^22.13.0 || >=24.\n'
     );

--- a/test/unit/components/framework/index.test.js
+++ b/test/unit/components/framework/index.test.js
@@ -99,7 +99,7 @@ describe('test/unit/components/framework/index.test.js', () => {
     expect(context.outputs).to.deep.equal({ Key: 'Output' });
   });
 
-  it('supports the shared spawn helper promise shape when executing framework commands', async () => {
+  it('supports the shared spawn helper promise shape when executing OSLS Framework commands', async () => {
     const spawnStub = sinon.stub();
     spawnStub.onFirstCall().returns(
       createSpawnExecution({
@@ -433,7 +433,7 @@ describe('test/unit/components/framework/index.test.js', () => {
     expect(spawnStub.getCall(0).args[2].cwd).to.equal('custom-path');
   });
 
-  it('passes documented nested Framework commands through to Serverless CLI', async () => {
+  it('passes documented nested OSLS Framework commands through to OSLS Framework CLI', async () => {
     const cases = [
       {
         command: 'deploy:function',
@@ -697,7 +697,7 @@ describe('test/unit/components/framework/index.test.js', () => {
     const context = await getContext();
     const component = new FrameworkComponent('some-id', context, { path: 'foo' });
     await expect(component.deploy()).to.eventually.be.rejectedWith(
-      'The installed version of Serverless Framework (2.1.0) is not supported by Compose. Please upgrade Serverless Framework to a version greater or equal to "3.7.7"'
+      'The installed version of OSLS Framework (2.1.0) is not supported by Compose. Please upgrade OSLS Framework to a version greater or equal to "3.7.7"'
     );
   });
 

--- a/test/unit/components/framework/index.test.js
+++ b/test/unit/components/framework/index.test.js
@@ -433,7 +433,7 @@ describe('test/unit/components/framework/index.test.js', () => {
     expect(spawnStub.getCall(0).args[2].cwd).to.equal('custom-path');
   });
 
-  it('passes documented nested osls commands through to osls CLI', async () => {
+  it('passes documented nested osls commands through to the osls CLI', async () => {
     const cases = [
       {
         command: 'deploy:function',
@@ -697,7 +697,7 @@ describe('test/unit/components/framework/index.test.js', () => {
     const context = await getContext();
     const component = new FrameworkComponent('some-id', context, { path: 'foo' });
     await expect(component.deploy()).to.eventually.be.rejectedWith(
-      'The installed version of osls (2.1.0) is not supported by osls compose. Please upgrade osls to a version greater or equal to "3.7.7"'
+      'The installed version of osls (2.1.0) is not supported by osls compose. Please upgrade osls to a version greater than or equal to "3.7.7"'
     );
   });
 

--- a/test/unit/components/framework/index.test.js
+++ b/test/unit/components/framework/index.test.js
@@ -99,7 +99,7 @@ describe('test/unit/components/framework/index.test.js', () => {
     expect(context.outputs).to.deep.equal({ Key: 'Output' });
   });
 
-  it('supports the shared spawn helper promise shape when executing OSLS Framework commands', async () => {
+  it('supports the shared spawn helper promise shape when executing osls commands', async () => {
     const spawnStub = sinon.stub();
     spawnStub.onFirstCall().returns(
       createSpawnExecution({
@@ -433,7 +433,7 @@ describe('test/unit/components/framework/index.test.js', () => {
     expect(spawnStub.getCall(0).args[2].cwd).to.equal('custom-path');
   });
 
-  it('passes documented nested OSLS Framework commands through to OSLS Framework CLI', async () => {
+  it('passes documented nested osls commands through to osls CLI', async () => {
     const cases = [
       {
         command: 'deploy:function',
@@ -697,7 +697,7 @@ describe('test/unit/components/framework/index.test.js', () => {
     const context = await getContext();
     const component = new FrameworkComponent('some-id', context, { path: 'foo' });
     await expect(component.deploy()).to.eventually.be.rejectedWith(
-      'The installed version of OSLS Framework (2.1.0) is not supported by Compose. Please upgrade OSLS Framework to a version greater or equal to "3.7.7"'
+      'The installed version of osls (2.1.0) is not supported by osls compose. Please upgrade osls to a version greater or equal to "3.7.7"'
     );
   });
 

--- a/test/unit/src/components-service.test.js
+++ b/test/unit/src/components-service.test.js
@@ -958,7 +958,7 @@ describe('test/unit/src/components-service.test.js', () => {
     ).to.eventually.be.rejected.and.have.property('code', 'COMPONENT_COMMAND_NOT_FOUND');
   });
 
-  it('passes nested commands through for Serverless Framework services', async () => {
+  it('passes nested commands through for services', async () => {
     const command = sinon.stub().resolves();
 
     class FakeServerlessFramework {

--- a/test/unit/src/configuration/validate.test.js
+++ b/test/unit/src/configuration/validate.test.js
@@ -54,7 +54,7 @@ describe('test/unit/src/configuration/validate.test.js', () => {
       .and.have.property('code', 'INVALID_NON_OBJECT_SERVICE_CONFIGURATION');
   });
 
-  it('rejects configuration that contains Framework-specific properties', () => {
+  it('rejects configuration that contains OSLS Framework-specific properties', () => {
     expect(() =>
       validateConfiguration(
         {
@@ -68,7 +68,7 @@ describe('test/unit/src/configuration/validate.test.js', () => {
       .and.have.property('code', 'INVALID_CONFIGURATION');
   });
 
-  it('ignores inherited Framework-specific properties', () => {
+  it('ignores inherited OSLS Framework-specific properties', () => {
     const configuration = Object.create({ provider: {} });
     configuration.services = {};
 

--- a/test/unit/src/configuration/validate.test.js
+++ b/test/unit/src/configuration/validate.test.js
@@ -54,7 +54,7 @@ describe('test/unit/src/configuration/validate.test.js', () => {
       .and.have.property('code', 'INVALID_NON_OBJECT_SERVICE_CONFIGURATION');
   });
 
-  it('rejects configuration that contains OSLS Framework-specific properties', () => {
+  it('rejects configuration that contains osls-specific properties', () => {
     expect(() =>
       validateConfiguration(
         {
@@ -68,7 +68,7 @@ describe('test/unit/src/configuration/validate.test.js', () => {
       .and.have.property('code', 'INVALID_CONFIGURATION');
   });
 
-  it('ignores inherited OSLS Framework-specific properties', () => {
+  it('ignores inherited osls-specific properties', () => {
     const configuration = Object.create({ provider: {} });
     configuration.services = {};
 

--- a/test/unit/src/index.test.js
+++ b/test/unit/src/index.test.js
@@ -356,7 +356,7 @@ describe('test/unit/src/index.test.js', () => {
     expect(processExit).to.have.been.calledOnceWithExactly(0);
   });
 
-  it('allows OSLS Framework options for nested passthrough commands after normalization', async () => {
+  it('allows osls options for nested passthrough commands after normalization', async () => {
     const componentsServiceInstance = {
       init: sinon.stub().resolves(),
       invokeComponentCommand: sinon.stub().resolves(),

--- a/test/unit/src/index.test.js
+++ b/test/unit/src/index.test.js
@@ -356,7 +356,7 @@ describe('test/unit/src/index.test.js', () => {
     expect(processExit).to.have.been.calledOnceWithExactly(0);
   });
 
-  it('allows Framework options for nested passthrough commands after normalization', async () => {
+  it('allows OSLS Framework options for nested passthrough commands after normalization', async () => {
     const componentsServiceInstance = {
       init: sinon.stub().resolves(),
       invokeComponentCommand: sinon.stub().resolves(),

--- a/test/unit/src/validate-options.test.js
+++ b/test/unit/src/validate-options.test.js
@@ -20,7 +20,7 @@ describe('test/unit/src/validate-options.test.js', () => {
     validateOptions({ package: '../something' }, 'invoke');
   });
 
-  it('accepts Framework options for nested passthrough commands', () => {
+  it('accepts OSLS Framework options for nested passthrough commands', () => {
     validateOptions({ function: 'handler' }, 'deploy:function');
     validateOptions({ function: 'handler' }, 'invoke:local');
     validateOptions({ 'function': 'handler', 'function-version': '23' }, 'rollback:function');

--- a/test/unit/src/validate-options.test.js
+++ b/test/unit/src/validate-options.test.js
@@ -10,17 +10,17 @@ describe('test/unit/src/validate-options.test.js', () => {
       .and.have.property('code', 'INVALID_GLOBAL_CLI_OPTION');
   });
 
-  it('rejects unrecognized options for native global Compose commands', () => {
+  it('rejects unrecognized options for native global osls compose commands', () => {
     expect(() => validateOptions({ package: '../something' }, 'deploy'))
       .to.throw()
       .and.have.property('code', 'UNRECOGNIZED_CLI_OPTIONS');
   });
 
-  it('accepts custom options for non-native Compose commands', () => {
+  it('accepts custom options for non-native osls compose commands', () => {
     validateOptions({ package: '../something' }, 'invoke');
   });
 
-  it('accepts OSLS Framework options for nested passthrough commands', () => {
+  it('accepts osls options for nested passthrough commands', () => {
     validateOptions({ function: 'handler' }, 'deploy:function');
     validateOptions({ function: 'handler' }, 'invoke:local');
     validateOptions({ 'function': 'handler', 'function-version': '23' }, 'rollback:function');


### PR DESCRIPTION
- Rebrand user-facing Compose text to OSLS Compose.
- Update OSLS Framework references and documentation links for the planned `oss-serverless/framework` rename.
- Keep command names and compatibility parsing intact.
