### PR TITLE
Remove redundant sinon cleanup

### DIFF
--- a/test/unit/bin/serverless-compose.test.js
+++ b/test/unit/bin/serverless-compose.test.js
@@ -12,10 +12,6 @@ describe('test/unit/bin/serverless-compose.test.js', () => {
     proxyquire.noCallThru().load('../../../bin/serverless-compose', stubs);
   };
 
-  afterEach(() => {
-    sinon.restore();
-  });
-
   it('exits before loading the runtime on unsupported Node versions', () => {
     process.argv = ['node', 'serverless-compose', 'deploy', '--verbose'];
     const isSupportedNodeVersion = sinon.stub().returns(false);

--- a/test/unit/src/cli/Progresses.test.js
+++ b/test/unit/src/cli/Progresses.test.js
@@ -31,7 +31,6 @@ describe('test/unit/src/cli/Progresses.test.js', () => {
       delete Progresses.lastBoundInstance;
     }
     loadedProgresses = [];
-    sinon.restore();
   });
 
   const createProgresses = (columns = 5, rows = 3) => {

--- a/test/unit/src/index.test.js
+++ b/test/unit/src/index.test.js
@@ -27,7 +27,6 @@ describe('test/unit/src/index.test.js', () => {
   afterEach(() => {
     for (const snapshot of listenerSnapshots) restoreAddedListeners(snapshot);
     listenerSnapshots = [];
-    sinon.restore();
   });
 
   const loadRunComponents = (componentsServiceInstances, validateOptions = sinon.stub()) => {

--- a/test/unit/src/utils/progress-footer.test.js
+++ b/test/unit/src/utils/progress-footer.test.js
@@ -69,7 +69,6 @@ const createFooter = (options = {}) => {
 describe('test/unit/src/utils/progress-footer.test.js', () => {
   afterEach(() => {
     delete require.cache[require.resolve(modulePath)];
-    sinon.restore();
   });
 
   it('writes array progress rows', () => {


### PR DESCRIPTION
This removes local Sinon restoration from process and global-state tests that already run under the Mocha root hook. The tests keep their explicit cleanup for module cache entries, process listeners, platform descriptors, stream overrides, and Progresses static state.