### PR TITLE
Clean up utility test setup

### DIFF
--- a/test/unit/src/configuration/resolve-path.test.js
+++ b/test/unit/src/configuration/resolve-path.test.js
@@ -1,7 +1,6 @@
 'use strict';
 
 const fs = require('node:fs').promises;
-const os = require('node:os');
 const path = require('node:path');
 const { expect } = require('chai');
 
@@ -12,7 +11,7 @@ describe('test/unit/src/configuration/resolve-path.test.js', () => {
   let tmpDir;
 
   beforeEach(async () => {
-    tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), 'compose-resolve-path-'));
+    tmpDir = await fs.mkdtemp(path.join(process.cwd(), 'compose-resolve-path-'));
   });
 
   afterEach(async () => {

--- a/test/unit/src/state/LocalStateStorage.test.js
+++ b/test/unit/src/state/LocalStateStorage.test.js
@@ -1,6 +1,5 @@
 'use strict';
 
-const os = require('os');
 const path = require('path');
 const fsp = require('fs').promises;
 const expect = require('chai').expect;
@@ -12,7 +11,7 @@ describe('test/unit/src/state/LocalStateStorage.test.js', () => {
   let rootDir;
 
   beforeEach(async () => {
-    rootDir = await fsp.mkdtemp(path.join(os.tmpdir(), 'compose-local-state-'));
+    rootDir = await fsp.mkdtemp(path.join(process.cwd(), 'compose-local-state-'));
     await ensureDir(path.join(rootDir, '.serverless'));
   });
 

--- a/test/unit/src/utils/cache-hash.test.js
+++ b/test/unit/src/utils/cache-hash.test.js
@@ -2,7 +2,6 @@
 
 const fs = require('node:fs').promises;
 const crypto = require('node:crypto');
-const os = require('node:os');
 const path = require('node:path');
 const proxyquire = require('proxyquire');
 const { expect } = require('chai');
@@ -25,7 +24,7 @@ describe('test/unit/src/utils/cache-hash.test.js', () => {
   let tmpDir;
 
   beforeEach(async () => {
-    tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), 'compose-cache-hash-'));
+    tmpDir = await fs.mkdtemp(path.join(process.cwd(), 'compose-cache-hash-'));
   });
 
   afterEach(async () => {
@@ -87,7 +86,7 @@ describe('test/unit/src/utils/cache-hash.test.js', () => {
   });
 
   it('does not include file paths in cache hashes', async () => {
-    const otherDir = await fs.mkdtemp(path.join(os.tmpdir(), 'compose-cache-hash-other-'));
+    const otherDir = await fs.mkdtemp(path.join(process.cwd(), 'compose-cache-hash-other-'));
 
     try {
       await outputFile(path.join(tmpDir, 'one.txt'), 'content\n');

--- a/test/unit/src/utils/fs.test.js
+++ b/test/unit/src/utils/fs.test.js
@@ -2,7 +2,6 @@
 
 const fs = require('node:fs');
 const fsp = fs.promises;
-const os = require('node:os');
 const path = require('node:path');
 const proxyquire = require('proxyquire');
 const sinon = require('sinon');
@@ -16,7 +15,7 @@ describe('test/unit/src/utils/fs.test.js', () => {
   let tmpDir;
 
   beforeEach(async () => {
-    tmpDir = await fsp.mkdtemp(path.join(os.tmpdir(), 'compose-fs-'));
+    tmpDir = await fsp.mkdtemp(path.join(process.cwd(), 'compose-fs-'));
   });
 
   afterEach(async () => {

--- a/test/unit/src/utils/glob.test.js
+++ b/test/unit/src/utils/glob.test.js
@@ -1,7 +1,6 @@
 'use strict';
 
 const fs = require('node:fs').promises;
-const os = require('node:os');
 const path = require('node:path');
 const { expect } = require('chai');
 
@@ -12,7 +11,7 @@ describe('test/unit/src/utils/glob.test.js', () => {
   let tmpDir;
 
   beforeEach(async () => {
-    tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), 'compose-glob-'));
+    tmpDir = await fs.mkdtemp(path.join(process.cwd(), 'compose-glob-'));
   });
 
   afterEach(async () => {

--- a/test/unit/src/utils/serverless-utils/log-reporters/node/progress-reporter.test.js
+++ b/test/unit/src/utils/serverless-utils/log-reporters/node/progress-reporter.test.js
@@ -7,10 +7,6 @@ const sinon = require('sinon');
 const expect = chai.expect;
 
 describe('test/unit/src/utils/serverless-utils/log-reporters/node/progress-reporter.test.js', () => {
-  afterEach(() => {
-    sinon.restore();
-  });
-
   const loadProgressReporter = () => {
     const handlers = new Map();
     const cliProgressFooter = {

--- a/test/unit/src/utils/spawn.test.js
+++ b/test/unit/src/utils/spawn.test.js
@@ -1,7 +1,6 @@
 'use strict';
 
 const fs = require('fs').promises;
-const os = require('os');
 const path = require('path');
 const { EventEmitter } = require('events');
 const nodeStream = require('stream');
@@ -74,7 +73,7 @@ const assertRedaction = async ({ args, redacted, visible = [] }) => {
 
 describe('spawn', () => {
   it('executes PATH shims through cross-platform resolution', async () => {
-    const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), 'spawn-shim-'));
+    const tempDir = await fs.mkdtemp(path.join(process.cwd(), 'spawn-shim-'));
     const commandName = `spawn-shim-${process.pid}-${Date.now()}`;
     const commandPath = path.join(
       tempDir,


### PR DESCRIPTION
This cleans up utility test setup by creating temporary directories under the Mocha sandbox cwd while keeping explicit per-test cleanup. It removes a redundant local Sinon restore in the node progress reporter coverage because the suite root hook already handles that cleanup.