### PR TITLE
Remove redundant AWS utility cleanup

### DIFF
--- a/test/unit/src/utils/aws/credentials.test.js
+++ b/test/unit/src/utils/aws/credentials.test.js
@@ -74,10 +74,6 @@ describe('test/unit/src/utils/aws/credentials.test.js', () => {
     });
   }
 
-  afterEach(() => {
-    sinon.restore();
-  });
-
   it('does not mutate AWS_PROFILE when AWS_DEFAULT_PROFILE is set', async () => {
     await withEnv(async () => {
       process.env.AWS_DEFAULT_PROFILE = 'custom-default';

--- a/test/unit/src/utils/aws/get-client-config.test.js
+++ b/test/unit/src/utils/aws/get-client-config.test.js
@@ -7,10 +7,6 @@ const sinon = require('sinon');
 const expect = chai.expect;
 
 describe('test/unit/src/utils/aws/get-client-config.test.js', () => {
-  afterEach(() => {
-    sinon.restore();
-  });
-
   it('builds client config with resolved credentials', () => {
     const getCredentialProvider = sinon.stub().returns('creds');
     const buildClientConfig = sinon.stub().returns('client-config');

--- a/test/unit/src/utils/aws/get-credential-provider.test.js
+++ b/test/unit/src/utils/aws/get-credential-provider.test.js
@@ -7,10 +7,6 @@ const sinon = require('sinon');
 const expect = chai.expect;
 
 describe('test/unit/src/utils/aws/get-credential-provider.test.js', () => {
-  afterEach(() => {
-    sinon.restore();
-  });
-
   it('forwards profile and stage to the aligned credential resolver', () => {
     const credentialProvider = sinon.stub().returns('provider');
 


### PR DESCRIPTION
This removes redundant local Sinon teardown from AWS utility tests now that the Mocha root hook restores Sinon after each test. It keeps the explicit AWS environment isolation in credential coverage and leaves the existing proxyquire seams intact.