### PR TITLE
Centralize AWS test env cleanup

### DIFF
--- a/test/lib/env.js
+++ b/test/lib/env.js
@@ -1,0 +1,19 @@
+'use strict';
+
+const withClearedEnv = async (keys, callback) => {
+  const originalEnv = new Map(keys.map((key) => [key, process.env[key]]));
+
+  for (const key of keys) delete process.env[key];
+
+  try {
+    return await callback();
+  } finally {
+    for (const key of keys) {
+      const value = originalEnv.get(key);
+      if (value === undefined) delete process.env[key];
+      else process.env[key] = value;
+    }
+  }
+};
+
+module.exports = { withClearedEnv };

--- a/test/unit/src/utils/aws/config.test.js
+++ b/test/unit/src/utils/aws/config.test.js
@@ -3,6 +3,8 @@
 const chai = require('chai');
 const proxyquire = require('proxyquire');
 
+const { withClearedEnv } = require('../../../../lib/env');
+
 const { expect } = chai;
 
 describe('test/unit/src/utils/aws/config.test.js', () => {
@@ -25,21 +27,7 @@ describe('test/unit/src/utils/aws/config.test.js', () => {
     'https_cafile',
   ];
 
-  async function withEnv(callback) {
-    const originalEnv = new Map(envKeys.map((key) => [key, process.env[key]]));
-
-    for (const key of envKeys) delete process.env[key];
-
-    try {
-      return await callback();
-    } finally {
-      for (const key of envKeys) {
-        const value = originalEnv.get(key);
-        if (value === undefined) delete process.env[key];
-        else process.env[key] = value;
-      }
-    }
-  }
+  const withEnv = (callback) => withClearedEnv(envKeys, callback);
 
   function loadConfig() {
     function FakeNodeHttpHandler(options) {

--- a/test/unit/src/utils/aws/credentials.test.js
+++ b/test/unit/src/utils/aws/credentials.test.js
@@ -5,6 +5,8 @@ const path = require('path');
 const proxyquire = require('proxyquire');
 const sinon = require('sinon');
 
+const { withClearedEnv } = require('../../../../lib/env');
+
 const { expect } = chai;
 
 describe('test/unit/src/utils/aws/credentials.test.js', () => {
@@ -25,21 +27,7 @@ describe('test/unit/src/utils/aws/credentials.test.js', () => {
     'AWS_CONFIG_FILE',
   ];
 
-  async function withEnv(callback) {
-    const originalEnv = new Map(envKeys.map((key) => [key, process.env[key]]));
-
-    for (const key of envKeys) delete process.env[key];
-
-    try {
-      return await callback();
-    } finally {
-      for (const key of envKeys) {
-        const value = originalEnv.get(key);
-        if (value === undefined) delete process.env[key];
-        else process.env[key] = value;
-      }
-    }
-  }
+  const withEnv = (callback) => withClearedEnv(envKeys, callback);
 
   function createMissingFileError() {
     return Object.assign(new Error('missing'), { code: 'ENOENT' });


### PR DESCRIPTION
This centralizes AWS test environment cleanup in a shared test helper used by the AWS config and credential coverage. It preserves each file's explicit environment variable list while removing duplicated snapshot and restore logic.