### PR TITLE
Upgrade eslint

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -1,37 +1,36 @@
-'use strict';
-
-const js = require('@eslint/js');
-const globals = require('globals');
-const importX = require('eslint-plugin-import-x');
-const n = require('eslint-plugin-n');
-const eslintConfigPrettier = require('eslint-config-prettier/flat');
+import js from '@eslint/js';
+import globals from 'globals';
+import { flatConfigs as importXFlatConfigs } from 'eslint-plugin-import-x';
+import n from 'eslint-plugin-n';
+import eslintConfigPrettier from 'eslint-config-prettier/flat';
+import { defineConfig, globalIgnores } from 'eslint/config';
 
 const devDependencyFiles = [
   '**/*.test.js',
   '**/scripts/**',
   '**/test/**',
   '**/tests/**',
-  'eslint.config.js',
+  'eslint.config.mjs',
   'prettier.config.js',
 ];
 
-module.exports = [
+export default defineConfig([
   {
+    name: 'compose/linter-options',
     linterOptions: {
       reportUnusedDisableDirectives: 'warn',
     },
   },
-  {
-    ignores: ['**/.*'],
-  },
+  globalIgnores(['**/.*']),
   js.configs.recommended,
   n.configs['flat/recommended-script'],
-  importX.flatConfigs.recommended,
+  importXFlatConfigs.recommended,
   eslintConfigPrettier,
   {
+    name: 'compose/javascript',
     files: ['**/*.{cjs,js,mjs}', 'bin/serverless-compose'],
     languageOptions: {
-      ecmaVersion: 2023,
+      ecmaVersion: 2025,
       sourceType: 'commonjs',
       globals: {
         ...globals.node,
@@ -52,28 +51,36 @@ module.exports = [
           caughtErrors: 'all',
         },
       ],
+      'n/no-extraneous-import': 'off',
       'n/no-unsupported-features/node-builtins': ['error', { allowExperimental: true }],
       'n/no-extraneous-require': 'off',
+      'n/no-missing-import': 'off',
+      'n/no-unpublished-import': 'off',
       'n/no-unpublished-require': 'off',
       'n/no-missing-require': 'off',
       'n/no-process-exit': 'off',
       'n/no-deprecated-api': 'off',
       'n/hashbang': 'off',
+      'n/no-unpublished-bin': 'error',
     },
   },
   {
+    name: 'compose/published-files',
     files: ['bin/serverless-compose', 'components/**/*.js', 'src/**/*.js'],
     rules: {
+      'n/no-unpublished-import': 'error',
       'n/no-unpublished-require': 'error',
     },
   },
   {
+    name: 'compose/modules',
     files: ['**/*.mjs'],
     languageOptions: {
       sourceType: 'module',
     },
   },
   {
+    name: 'compose/tests',
     files: ['**/*.test.js', '**/test/**'],
     languageOptions: {
       globals: globals.mocha,
@@ -82,4 +89,4 @@ module.exports = [
       'no-unused-expressions': 'off',
     },
   },
-];
+]);

--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "eslint": "^10.2.1",
     "eslint-config-prettier": "^10.1.8",
     "eslint-plugin-import-x": "^4.16.2",
-    "eslint-plugin-n": "^17.24.0",
+    "eslint-plugin-n": "^18.1.0",
     "git-list-updated": "^1.2.1",
     "globals": "^17.5.0",
     "mocha": "12.0.0-beta-9.2",


### PR DESCRIPTION
This upgrades our eslint setup to match the recent changes in the main osls repository. The configuration file has been renamed from eslint.config.js to eslint.config.mjs and converted to an ES module, now using the defineConfig and globalIgnores helpers from eslint/config. Each configuration block has been given a name to make eslint's config inspection output easier to follow, and the ecmaVersion has been raised from 2023 to 2025. Finally, eslint-plugin-n has been upgraded from v17 to v18, with the rule set adjusted to disable the import-flavoured resolution checks that do not fit this CommonJS codebase, while enforcing n/no-unpublished-import on published files and enabling n/no-unpublished-bin.