### PR TITLE
Upgrade to `simon` 22

### DIFF
--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
     "mocha": "12.0.0-beta-9.2",
     "prettier": "^3.8.3",
     "proxyquire": "^2.1.3",
-    "sinon": "^21.1.2",
+    "sinon": "^22.0.0",
     "sinon-chai": "^4.0.1"
   },
   "engines": {


### PR DESCRIPTION
This upgrades sinon from v21 to v22, matching the equivalent upgrade already made in the main osls repository. No code changes were required, and the full test suite passes against the new version.