### PR TITLE
Upgrade to mocha 12.0.0-beta-9.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
     "eslint-plugin-n": "^17.24.0",
     "git-list-updated": "^1.2.1",
     "globals": "^17.5.0",
-    "mocha": "12.0.0-beta-9.2",
+    "mocha": "12.0.0-beta-9.4",
     "prettier": "^3.8.3",
     "proxyquire": "^2.1.3",
     "sinon": "^21.1.2",


### PR DESCRIPTION
This bumps our pinned mocha version from 12.0.0-beta-9.2 to 12.0.0-beta-9.4, matching the version already in use in the main osls repository. The full test suite passes against the new version.