### PR TITLE
Use longer random suffixes for generated names

### DIFF
--- a/src/state/utils/get-state-bucket-name.js
+++ b/src/state/utils/get-state-bucket-name.js
@@ -57,7 +57,7 @@ const ensureRemoteStateBucketStackExists = async (context, stateConfiguration) =
   // TODO: REPLACE WITH PROGRESS
   context.output.log('Creating S3 bucket for remote state');
 
-  const bucketName = `serverless-compose-state-${crypto.randomBytes(6).toString('hex')}`;
+  const bucketName = `serverless-compose-state-${crypto.randomBytes(12).toString('hex')}`;
   await client.createStack({
     StackName: COMPOSE_REMOTE_STATE_STACK_NAME,
     TemplateBody: templateBody,

--- a/test/unit/src/state/utils/get-state-bucket-name.test.js
+++ b/test/unit/src/state/utils/get-state-bucket-name.test.js
@@ -75,9 +75,9 @@ describe('test/unit/src/state/utils/get-state-bucket-name.test.js', () => {
         .on(DescribeStacksCommand)
         .resolves({ Stacks: [{ StackStatus: 'CREATE_COMPLETE' }] });
 
-      expect(
-        (await getStateBucketName(configuration, context)).startsWith('serverless-compose-state-')
-      ).to.be.true;
+      expect(await getStateBucketName(configuration, context)).to.match(
+        /^serverless-compose-state-[a-f0-9]{24}$/
+      );
     });
 
     it('handles SDK v3 ValidationError names when bucket stack has to be created', async () => {
@@ -92,9 +92,9 @@ describe('test/unit/src/state/utils/get-state-bucket-name.test.js', () => {
         .on(DescribeStacksCommand)
         .resolves({ Stacks: [{ StackStatus: 'CREATE_COMPLETE' }] });
 
-      expect(
-        (await getStateBucketName(configuration, context)).startsWith('serverless-compose-state-')
-      ).to.be.true;
+      expect(await getStateBucketName(configuration, context)).to.match(
+        /^serverless-compose-state-[a-f0-9]{24}$/
+      );
     });
 
     it('handles unexpected error when resolving bucket from s3', async () => {

--- a/test/unit/src/utils/spawn.test.js
+++ b/test/unit/src/utils/spawn.test.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const fs = require('fs').promises;
+const crypto = require('crypto');
 const path = require('path');
 const { EventEmitter } = require('events');
 const nodeStream = require('stream');
@@ -74,7 +75,7 @@ const assertRedaction = async ({ args, redacted, visible = [] }) => {
 describe('spawn', () => {
   it('executes PATH shims through cross-platform resolution', async () => {
     const tempDir = await fs.mkdtemp(path.join(process.cwd(), 'spawn-shim-'));
-    const commandName = `spawn-shim-${process.pid}-${Date.now()}`;
+    const commandName = `spawn-shim-${crypto.randomBytes(12).toString('hex')}`;
     const commandPath = path.join(
       tempDir,
       process.platform === 'win32' ? `${commandName}.cmd` : commandName


### PR DESCRIPTION
This change increases the random suffix used when creating generated S3 state bucket names from six random bytes to twelve random bytes encoded as hexadecimal. It also replaces the spawn test shim filename suffix based on process id and Date.now() with the same twelve-byte hexadecimal random suffix, while keeping the existing randomId helper unchanged.